### PR TITLE
Default Values(array) not evaluated correctly

### DIFF
--- a/app/react-selectlist.jsx
+++ b/app/react-selectlist.jsx
@@ -34,7 +34,7 @@ export class ReactSelectList extends React.Component{
     if(multiple){
       this.data.map((item,index)=>{
         if(_.isArray(value)){
-          if(_.contains(item[valueField],value)){
+          if(_.contains(value,item[valueField])){
             item.checked=true;
           }
           else{

--- a/dist/react-selectlist.js
+++ b/dist/react-selectlist.js
@@ -196,7 +196,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (multiple) {
 	      _this3.data.map(function (item, index) {
 	        if (_underscore2.default.isArray(value)) {
-	          if (_underscore2.default.contains(item[valueField], value)) {
+	          if (_underscore2.default.contains(value, item[valueField])) {
 	            item.checked = true;
 	          } else {
 	            item.checked = false;


### PR DESCRIPTION
Found a small bug. If you use the 'value' prop and supply an array, no defaults will be selected. Looks like the order of the parameters got switched around.

Here's an example of the order working correctly using underscore.
https://jsfiddle.net/1nh6jgrx/